### PR TITLE
fix(docs): add missing instruction in keyboard setup instructions for macOS

### DIFF
--- a/docs/_shared/layout_teclado.md
+++ b/docs/_shared/layout_teclado.md
@@ -31,7 +31,7 @@ No Windows 11, a imagem abaixo representam respectivamente o computador com 2 la
 
 No Mac, o fluxo pode ser diferente. A princípio, siga o seguinte fluxo para configurar o teclado no padrão internacional (ASNI):
 
-`System Settings > Change Keyboard Type > ANSI (U.S.)`
+`System Settings > Keyword > Change Keyboard Type > ANSI (U.S.)`
 
 </details>
 


### PR DESCRIPTION
First we need to open Keyboard settings to Change Keyboard Type
![Screenshot 2025-06-16 at 18 54 04](https://github.com/user-attachments/assets/01d2c127-77dd-4382-a538-212c93e8ae33)

